### PR TITLE
Remove device before and after

### DIFF
--- a/vpn_connect.sh
+++ b/vpn_connect.sh
@@ -37,6 +37,10 @@ Step "Get default device and gateway"
     Message "Gateway: $GW"
 Done
 
+Step "Remove device ppp0"
+    ip link delete ppp0
+Done
+
 Step "Add route for the VPN server"
     ip route add 137.189.88.231 via $GW dev $DEV > /dev/null 2>&1
 Done

--- a/vpn_disconnect.sh
+++ b/vpn_disconnect.sh
@@ -31,10 +31,6 @@ Step "Get original device and gateway"
     Message "Gateway: $GW"
 Done
 
-Step "Remove device ppp0"
-    ip link delete ppp0
-Done
-
 Step "Disconnect from the VPN server"
     echo "d" > /var/run/xl2tpd/l2tp-control
     sleep 1

--- a/vpn_disconnect.sh
+++ b/vpn_disconnect.sh
@@ -31,6 +31,10 @@ Step "Get original device and gateway"
     Message "Gateway: $GW"
 Done
 
+Step "Remove device ppp0"
+    ip link delete ppp0
+Done
+
 Step "Disconnect from the VPN server"
     echo "d" > /var/run/xl2tpd/l2tp-control
     sleep 1
@@ -40,6 +44,10 @@ Step "Restore default route"
     ip route del default > /dev/null 2>&1
     ip route add default via $GW dev $DEV > /dev/null 2>&1
     sed -i /137\.189\.192\.[36]/d /etc/resolv.conf
+Done
+
+Step "Remove device ppp0"
+    ip link delete ppp0
 Done
 
 Message "The connection should be disconnected."


### PR DESCRIPTION
Currently the scripts do not remove device `ppp0` after running `vpn_disconnect.sh` or the VPN accidentally goes down.
After which sending `"c connect"` to `l2tp-control` will result in creation of new devices `ppp*` (`ppp1`, `ppp2`, so on).
The VPN will then fail as it uses outdated device `ppp0`.
Removing device `ppp0` before start sending `"c connect"` to `l2tp-control` and at end of `vpn_disconnect.sh` solves the issues.